### PR TITLE
Potential fix for code scanning alert no. 10: Unsafe jQuery plugin

### DIFF
--- a/javascripts/jquery.tablesorter.js
+++ b/javascripts/jquery.tablesorter.js
@@ -2345,7 +2345,7 @@
 		// detach tbody but save the position
 		// don't use tbody because there are portions that look for a tbody index (updateCell)
 		processTbody : function( table, $tb, getIt ) {
-			table = $( table )[ 0 ];
+			table = $( table ).filter('table')[0];
 			if ( getIt ) {
 				table.isProcessing = true;
 				$tb.before( '<colgroup class="tablesorter-savemyplace"/>' );


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/10](https://github.com/i5k/i5k.github.io/security/code-scanning/10)

To fix the problem, we need to ensure that any user-provided input is properly sanitized before being used in the plugin. Specifically, we should avoid using jQuery functions that can interpret strings as HTML when dealing with user input. Instead, we should use safer alternatives that treat the input as a CSS selector or plain text.

In this case, we can modify the `processTbody` function to ensure that the `table` variable is always treated as a DOM element and not as a string that can be interpreted as HTML. We can achieve this by using jQuery's `find` method to ensure that the input is treated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
