### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/assets/js/plugins/jquery.magnific-popup.js
+++ b/assets/js/plugins/jquery.magnific-popup.js
@@ -2,6 +2,7 @@
 * http://dimsemenov.com/plugins/magnific-popup/
 * Copyright (c) 2013 Dmitry Semenov; */
 ;(function($) {
+	var DOMPurify = require('dompurify');
 
 /*>>core*/
 /**
@@ -504,6 +505,7 @@ MagnificPopup.prototype = {
 			_mfpTrigger('FirstMarkupParse', markup);
 
 			if(markup) {
+				markup = DOMPurify.sanitize(markup);
 				mfp.currTemplate[type] = $(markup);
 			} else {
 				// if there is no markup found we just define that template is parsed

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "uglify": "uglifyjs assets/js/vendor/jquery/jquery-1.12.1.min.js assets/js/plugins/jquery.fitvids.js assets/js/plugins/jquery.greedy-navigation.js assets/js/plugins/jquery.magnific-popup.js assets/js/plugins/jquery.smooth-scroll.min.js assets/js/plugins/stickyfill.min.js assets/js/plugins/jquery.tablesorter.min.js assets/js/_main.js -c -m -o assets/js/main.min.js",
     "watch:js": "onchange \"assets/js/**/*.js\" -e \"assets/js/main.min.js\" -- npm run build:js",
     "build:js": "npm run uglify"
+  },
+  "dependencies": {
+    "dompurify": "^3.2.4"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/4](https://github.com/i5k/i5k.github.io/security/code-scanning/4)

To fix the problem, we need to ensure that the `markup` string is sanitized before it is used in the `$(markup)` call. This can be done by using a library like DOMPurify to sanitize the HTML string. DOMPurify is a well-known library for sanitizing HTML and preventing XSS attacks.

1. Import the DOMPurify library.
2. Sanitize the `markup` string before using it in the `$(markup)` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
