### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/assets/js/plugins/jquery.magnific-popup.js
+++ b/assets/js/plugins/jquery.magnific-popup.js
@@ -79,7 +79,8 @@ var _mfpOn = function(name, f) {
 	},
 	_getCloseBtn = function(type) {
 		if(type !== _currPopupType || !mfp.currTemplate.closeBtn) {
-			mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace('%title%', mfp.st.tClose ) );
+			var sanitizedCloseMarkup = DOMPurify.sanitize(mfp.st.closeMarkup.replace('%title%', mfp.st.tClose));
+			mfp.currTemplate.closeBtn = $(sanitizedCloseMarkup);
 			_currPopupType = type;
 		}
 		return mfp.currTemplate.closeBtn;


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/2](https://github.com/i5k/i5k.github.io/security/code-scanning/2)

To fix the problem, we need to sanitize the `mfp.st.closeMarkup` property before using it to construct HTML. This can be achieved by using a library like DOMPurify to sanitize the HTML content. We will modify the `_getCloseBtn` function to sanitize the `mfp.st.closeMarkup` property before using it.

1. Import the DOMPurify library.
2. Use DOMPurify to sanitize the `mfp.st.closeMarkup` property before using it to create the close button.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
