### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe jQuery plugin

### DIFF
--- a/assets/js/plugins/jquery.magnific-popup.js
+++ b/assets/js/plugins/jquery.magnific-popup.js
@@ -349,7 +349,8 @@ MagnificPopup.prototype = {
 		$('html').css(windowStyles);
 
 		// add everything to DOM
-		mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || _body );
+		var sanitizedPrependTo = DOMPurify.sanitize(mfp.st.prependTo || _body);
+		mfp.bgOverlay.add(mfp.wrap).prependTo(sanitizedPrependTo);
 
 		// Save last focused element
 		mfp._lastFocusedEl = document.activeElement;


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/3](https://github.com/i5k/i5k.github.io/security/code-scanning/3)

To fix the problem, we need to ensure that any user-provided data in the `options` object is properly sanitized before being used in the DOM. We can use a library like DOMPurify to sanitize the `options.prependTo` value. This will prevent any malicious content from being injected into the DOM.

The best way to fix the problem without changing existing functionality is to sanitize the `options.prependTo` value before it is used in the DOM. We will add a check to sanitize this value using DOMPurify.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
