### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe HTML constructed from library input

### DIFF
--- a/javascripts/jquery.tablesorter.js
+++ b/javascripts/jquery.tablesorter.js
@@ -1,12 +1,12 @@
 (function(factory) {
 	if (typeof define === 'function' && define.amd) {
-		define(['jquery'], factory);
+		define(['jquery', 'dompurify'], factory);
 	} else if (typeof module === 'object' && typeof module.exports === 'object') {
-		module.exports = factory(require('jquery'));
+		module.exports = factory(require('jquery'), require('dompurify'));
 	} else {
-		factory(jQuery);
+		factory(jQuery, window.DOMPurify);
 	}
-}(function(jQuery) {
+}(function(jQuery, DOMPurify) {
 
 /*! TableSorter (FORK) v2.27.6 *//*
 * Client-side table sorting with ease!
@@ -566,6 +566,7 @@
 							template = header;
 						}
 					}
+					template = DOMPurify.sanitize(template);
 					$elem.html( '<div class="' + ts.css.headerIn + '">' + template + '</div>' ); // faster than wrapInner
 				}
 				if ( c.onRenderHeader ) {
@@ -2769,7 +2770,7 @@
 		}
 		return settings;
 	}
-})( jQuery );
+})( jQuery, DOMPurify );
 
 return jQuery.tablesorter;
 }));


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/11](https://github.com/i5k/i5k.github.io/security/code-scanning/11)

To fix the problem, we need to ensure that any HTML content constructed from user input is properly sanitized before being inserted into the DOM. This can be achieved by using a library like `DOMPurify` to sanitize the HTML content. 

1. Import the `DOMPurify` library.
2. Use `DOMPurify` to sanitize the `template` variable before inserting it into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
