### PR TITLE
Potential fix for code scanning alert no. 9: Unsafe jQuery plugin

### DIFF
--- a/javascripts/jquery.tablesorter.js
+++ b/javascripts/jquery.tablesorter.js
@@ -2763,10 +2763,16 @@
 	});
 
 	function sanitizeSettings(settings) {
-		// Implement sanitization logic here
-		// For example, ensure selectors are treated as CSS selectors
-		if (settings && typeof settings.sourceSelector === 'string') {
-			settings.sourceSelector = jQuery.escapeSelector(settings.sourceSelector);
+		if (settings) {
+			// Ensure selectors are treated as CSS selectors
+			if (typeof settings.sourceSelector === 'string') {
+				settings.sourceSelector = jQuery.escapeSelector(settings.sourceSelector);
+			}
+			// Sanitize any HTML content using DOMPurify
+			if (typeof settings.htmlContent === 'string') {
+				settings.htmlContent = DOMPurify.sanitize(settings.htmlContent);
+			}
+			// Add more sanitization logic as needed for other properties
 		}
 		return settings;
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/9](https://github.com/i5k/i5k.github.io/security/code-scanning/9)

To fix the problem, we need to ensure that all user inputs in the `settings` object are properly sanitized before being used in the plugin. This involves extending the `sanitizeSettings` function to handle all relevant properties that could lead to unsafe HTML injection. Additionally, we should use DOMPurify to sanitize any HTML content that might be injected into the DOM.

1. Extend the `sanitizeSettings` function to sanitize all relevant properties in the `settings` object.
2. Use DOMPurify to sanitize any HTML content before it is injected into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
