### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe jQuery plugin

### DIFF
--- a/javascripts/jquery.tablesorter.js
+++ b/javascripts/jquery.tablesorter.js
@@ -2786,6 +2786,10 @@
 			if (typeof settings.cellHTML === 'string') {
 				settings.cellHTML = DOMPurify.sanitize(settings.cellHTML);
 			}
+			// Sanitize header data
+			if (typeof settings.headerData === 'string') {
+				settings.headerData = DOMPurify.sanitize(settings.headerData);
+			}
 			// Add more sanitization logic as needed for other properties
 		}
 		return settings;


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/7](https://github.com/i5k/i5k.github.io/security/code-scanning/7)

To fix the problem, we need to ensure that all user-provided settings are properly sanitized before being used in any jQuery selectors or HTML content. This involves extending the `sanitizeSettings` function to cover all possible properties that could lead to XSS and ensuring that the sanitization is thorough.

1. Extend the `sanitizeSettings` function to include additional properties that could be used in jQuery selectors or HTML content.
2. Use `jQuery.escapeSelector` for properties that are used as CSS selectors.
3. Use `DOMPurify.sanitize` for properties that are used as HTML content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
