### PR TITLE
Potential fix for code scanning alert no. 12: Unsafe jQuery plugin

### DIFF
--- a/javascripts/jquery.tablesorter.js
+++ b/javascripts/jquery.tablesorter.js
@@ -2780,6 +2780,14 @@
 			if (typeof settings.htmlContent === 'string') {
 				settings.htmlContent = DOMPurify.sanitize(settings.htmlContent);
 			}
+			// Sanitize other properties as needed
+			if (typeof settings.anotherProperty === 'string') {
+				settings.anotherProperty = DOMPurify.sanitize(settings.anotherProperty);
+			}
+			// Sanitize any HTML content using DOMPurify
+			if (typeof settings.htmlContent === 'string') {
+				settings.htmlContent = DOMPurify.sanitize(settings.htmlContent);
+			}
 			// Sanitize other properties that could lead to XSS
 			if (typeof settings.tableSelector === 'string') {
 				settings.tableSelector = jQuery.escapeSelector(settings.tableSelector);


### PR DESCRIPTION
Potential fix for [https://github.com/i5k/i5k.github.io/security/code-scanning/12](https://github.com/i5k/i5k.github.io/security/code-scanning/12)

To fix the problem, we need to ensure that all properties of the `settings` object that can be used in dynamic HTML construction are properly sanitized. We should extend the `sanitizeSettings` function to cover more properties and use a library like DOMPurify to sanitize any HTML content.

1. Extend the `sanitizeSettings` function to sanitize additional properties.
2. Use DOMPurify to sanitize any HTML content that might be used in dynamic HTML construction.
3. Ensure that the `table` variable is properly sanitized before use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
